### PR TITLE
Add get_error_messages/2 for custom msg_func

### DIFF
--- a/lib/cozy_params.ex
+++ b/lib/cozy_params.ex
@@ -75,13 +75,12 @@ defmodule CozyParams do
   Extract error messages from `%Ecto.Changeset{}`.
   """
   @doc since: "0.1.0"
-  def get_error_messages(%Ecto.Changeset{changes: changes} = changeset) do
-    errors_in_current_changset =
-      Ecto.Changeset.traverse_errors(changeset, fn {msg, opts} ->
-        Enum.reduce(opts, msg, fn {key, value}, acc ->
-          String.replace(acc, "%{#{key}}", to_string(value))
-        end)
-      end)
+  def get_error_messages(%Ecto.Changeset{} = changeset) do
+    get_error_messages(changeset, &default_msg/1)
+  end
+
+  def get_error_messages(%Ecto.Changeset{changes: changes} = changeset, msg_func) do
+    errors_in_current_changset = Ecto.Changeset.traverse_errors(changeset, msg_func)
 
     errors_in_nested_changeset =
       changes
@@ -92,5 +91,11 @@ defmodule CozyParams do
       errors_in_nested_changeset,
       errors_in_current_changset
     )
+  end
+
+  defp default_msg({msg, opts}) do
+    Enum.reduce(opts, msg, fn {key, value}, acc ->
+      String.replace(acc, "%{#{key}}", to_string(value))
+    end)
   end
 end

--- a/test/cozy_params_test.exs
+++ b/test/cozy_params_test.exs
@@ -93,4 +93,23 @@ defmodule CozyParamsTest do
                CozyParams.get_error_messages(changeset)
     end
   end
+
+  describe "get_error_messages/2" do
+    test "works with custom msg_func" do
+      defmodule DemoD do
+        import CozyParams
+
+        defparams :product_search do
+          field :name, :string, required: true
+        end
+
+        def translate_error({"can't be blank", _opts}), do: "は必須項目です"
+      end
+
+      assert {:error, params_changeset: changeset} = DemoD.product_search(%{})
+
+      assert %{name: ["は必須項目です"]} ==
+               CozyParams.get_error_messages(changeset, &DemoD.translate_error/1)
+    end
+  end
 end


### PR DESCRIPTION
Many thanks for the library.

I want to use Phoenix's `MyApp.ErrorHelpers.translate_error/1` which is generated by `phx.new` to translate errors.

These changes enable `CozyParams.get_error_messages` to hand over `msg_func` to [`Ecto.Changeset.traverse_errors/2`](https://hexdocs.pm/ecto/Ecto.Changeset.html#traverse_errors/2) and then I set the original `msg_func`  implementation using `String.replace` as default for backward compatibility.

