### PR TITLE
feat: support `:redact` field option

### DIFF
--- a/lib/cozy_params/schema/ast.ex
+++ b/lib/cozy_params/schema/ast.ex
@@ -66,6 +66,7 @@ defmodule CozyParams.Schema.AST do
     supported_opt_names = [
       # general
       :default,
+      :redact,
 
       # Ecto.Enum
       :values,

--- a/mix.exs
+++ b/mix.exs
@@ -17,7 +17,8 @@ defmodule CozyParams.MixProject do
       homepage_url: @source_url,
       docs: docs(),
       package: package(),
-      aliases: aliases()
+      aliases: aliases(),
+      consolidate_protocols: Mix.env() != :test
     ]
   end
 

--- a/test/cozy_params/schema_test.exs
+++ b/test/cozy_params/schema_test.exs
@@ -395,6 +395,20 @@ defmodule CozyParams.SchemaTest do
       assert {:ok, %{age: 6, alert_at: ~T[13:26:08]}} = Params.from(%{})
     end
 
+    test "supports option - :redact" do
+      defmodule ParamsWithRedactOption do
+        use CozyParams.Schema
+
+        schema do
+          field :password, :string, redact: true
+          field :required, :string, required: true
+        end
+      end
+
+      alias ParamsWithRedactOption, as: Params
+      assert Params.from(%{password: "sensitive"}) |> inspect() =~ "password: \"**redacted**\""
+    end
+
     test "supports option - :pre_cast" do
       defmodule ParamsWithPreCastOption do
         use CozyParams.Schema


### PR DESCRIPTION
Hi, @c4710n 

Recently I faced an issue that some sensitive information appears on application log.
(because I overlooked that `@derive {Inspect, except: [...]}` has no effect for changes inside a `Ecto.Changeset` and sent validation errors to `Logger`.)

This PR enables cozy_params to filter that kind of values (like password, token, phone number and so on) by using [`:redact` option](https://hexdocs.pm/ecto/Ecto.Schema.html#module-redacting-fields) of Ecto.Schema.